### PR TITLE
Change type signature: `AbstractTensorMap{<:Number,<:IndexSpace,N1,N2}`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -13,3 +13,10 @@ Features that are planned to be implemented before the release of v1.0.0, in no 
 - [ ] Rewrite documentation
 
 # Changelog
+
+### `AbstractTensorMap{E,S,N₁,N₂}`
+
+This adds the scalar type as a parameter to the `AbstractTensorMap` type. This is useful in
+the contexts where different types of tensors are used (`AdjointTensor`, `BraidingTensor`,
+...), which still have the same scalartype. Additionally, this removes many specializations
+for methods in order to reduce ambiguity errors.

--- a/ext/TensorKitChainRulesCoreExt.jl
+++ b/ext/TensorKitChainRulesCoreExt.jl
@@ -22,8 +22,8 @@ function _repartition(p::Union{IndexTuple,Index2Tuple}, ::Index2Tuple{N₁}) whe
     return _repartition(p, N₁)
 end
 function _repartition(p::Union{IndexTuple,Index2Tuple},
-                      ::AbstractTensorMap{<:Any,N₁}) where {N₁}
-    return _repartition(p, N₁)
+                      t::AbstractTensorMap)
+    return _repartition(p, numout(t))
 end
 
 TensorKit.block(t::ZeroTangent, c::Sector) = t
@@ -59,8 +59,8 @@ function ChainRulesCore.rrule(::typeof(Base.copy), t::AbstractTensorMap)
 end
 
 ChainRulesCore.ProjectTo(::T) where {T<:AbstractTensorMap} = ProjectTo{T}()
-function (::ProjectTo{T1})(x::T2) where {S,N1,N2,T1<:AbstractTensorMap{S,N1,N2},
-                                         T2<:AbstractTensorMap{S,N1,N2}}
+function (::ProjectTo{T1})(x::T2) where {S,N1,N2,T1<:AbstractTensorMap{<:Any,S,N1,N2},
+                                         T2<:AbstractTensorMap{<:Any,S,N1,N2}}
     T1 === T2 && return x
     y = similar(x, scalartype(T1))
     for (c, b) in blocks(y)

--- a/src/planar/planaroperations.jl
+++ b/src/planar/planaroperations.jl
@@ -22,7 +22,7 @@ function planartrace!(C::AbstractTensorMap,
     (N₃ = length(q₁)) == length(q₂) ||
         throw(IndexError("number of trace indices does not match"))
     N₁, N₂ = length(p₁), length(p₂)
-    
+
     @boundscheck begin
         numout(C) == N₁ || throw(IndexError("number of output indices does not match"))
         numin(C) == N₂ || throw(IndexError("number of input indices does not match"))

--- a/src/planar/planaroperations.jl
+++ b/src/planar/planaroperations.jl
@@ -1,20 +1,20 @@
 # planar versions of tensor operations add!, trace! and contract!
-function planaradd!(C::AbstractTensorMap{S,N₁,N₂},
-                    A::AbstractTensorMap{S},
+function planaradd!(C::AbstractTensorMap,
+                    A::AbstractTensorMap,
                     p::Index2Tuple{N₁,N₂},
                     α::Number,
                     β::Number,
-                    backend::Backend...) where {S,N₁,N₂}
+                    backend::Backend...) where {N₁,N₂}
     return add_transpose!(C, A, p, α, β, backend...)
 end
 
-function planartrace!(C::AbstractTensorMap{S,N₁,N₂},
-                      A::AbstractTensorMap{S},
+function planartrace!(C::AbstractTensorMap{N₁,N₂},
+                      A::AbstractTensorMap,
                       p::Index2Tuple{N₁,N₂},
                       q::Index2Tuple{N₃,N₃},
                       α::Number,
                       β::Number,
-                      backend::Backend...) where {S,N₁,N₂,N₃}
+                      backend::Backend...) where {N₁,N₂,N₃}
     if BraidingStyle(sectortype(S)) == Bosonic()
         return trace_permute!(C, A, p, q, α, β, backend...)
     end
@@ -44,16 +44,16 @@ function planartrace!(C::AbstractTensorMap{S,N₁,N₂},
     return C
 end
 
-function planarcontract!(C::AbstractTensorMap{S,N₁,N₂},
-                         A::AbstractTensorMap{S},
+function planarcontract!(C::AbstractTensorMap,
+                         A::AbstractTensorMap,
                          pA::Index2Tuple,
-                         B::AbstractTensorMap{S},
+                         B::AbstractTensorMap,
                          pB::Index2Tuple,
-                         pAB::Index2Tuple{N₁,N₂},
+                         pAB::Index2Tuple,
                          α::Number,
                          β::Number,
-                         backend::Backend...) where {S,N₁,N₂}
-    if BraidingStyle(sectortype(S)) == Bosonic()
+                         backend::Backend...)
+    if BraidingStyle(sectortype(C)) == Bosonic()
         return contract!(C, A, pA, B, pB, pAB, α, β, backend...)
     end
 

--- a/src/planar/planaroperations.jl
+++ b/src/planar/planaroperations.jl
@@ -1,34 +1,40 @@
 # planar versions of tensor operations add!, trace! and contract!
 function planaradd!(C::AbstractTensorMap,
                     A::AbstractTensorMap,
-                    p::Index2Tuple{N₁,N₂},
-                    α::Number,
-                    β::Number,
-                    backend::Backend...) where {N₁,N₂}
+                    p::Index2Tuple,
+                    α::Number, β::Number,
+                    backend::Backend...)
     return add_transpose!(C, A, p, α, β, backend...)
 end
 
-function planartrace!(C::AbstractTensorMap{<:Number,S,N₁,N₂},
-                      A::AbstractTensorMap{<:Number,S},
-                      p::Index2Tuple{N₁,N₂},
-                      q::Index2Tuple{N₃,N₃},
+function planartrace!(C::AbstractTensorMap,
+                      A::AbstractTensorMap,
+                      (p₁, p₂)::Index2Tuple,
+                      (q₁, q₂)::Index2Tuple,
                       α::Number,
                       β::Number,
-                      backend::Backend...) where {S,N₁,N₂,N₃}
+                      backend::Backend...)
+    (S = spacetype(C)) == spacetype(A) ||
+        throw(SpaceMismatch("incompatible spacetypes"))
     if BraidingStyle(sectortype(S)) == Bosonic()
         return trace_permute!(C, A, p, q, α, β, backend...)
     end
-
+    (N₃ = length(q₁)) == length(q₂) ||
+        throw(IndexError("number of trace indices does not match"))
+    N₁, N₂ = length(p₁), length(p₂)
+    
     @boundscheck begin
-        all(i -> space(A, p[1][i]) == space(C, i), 1:N₁) ||
-            throw(SpaceMismatch("trace: A = $(codomain(A))←$(domain(A)),
-                    C = $(codomain(C))←$(domain(C)), p1 = $(p1), p2 = $(p2)"))
-        all(i -> space(A, p[2][i]) == space(C, N₁ + i), 1:N₂) ||
-            throw(SpaceMismatch("trace: A = $(codomain(A))←$(domain(A)),
-                    C = $(codomain(C))←$(domain(C)), p1 = $(p1), p2 = $(p2)"))
-        all(i -> space(A, q[1][i]) == dual(space(A, q[2][i])), 1:N₃) ||
-            throw(SpaceMismatch("trace: A = $(codomain(A))←$(domain(A)),
-                    q1 = $(q1), q2 = $(q2)"))
+        numout(C) == N₁ || throw(IndexError("number of output indices does not match"))
+        numin(C) == N₂ || throw(IndexError("number of input indices does not match"))
+        all(i -> space(A, p₁[i]) == space(C, i), 1:N₁) ||
+            throw(SpaceMismatch("trace: A = $(space(A)),
+                    C = $(space(C)), p₁ = $(p₁), p₂ = $(p₂)"))
+        all(i -> space(A, p₂[i]) == space(C, N₁ + i), 1:N₂) ||
+            throw(SpaceMismatch("trace: A = $(space(A)),
+                    C = $(space(C)), p₁ = $(p₁), p₂ = $(p₂)"))
+        all(i -> space(A, q₁[i]) == dual(space(A, q₂[i])), 1:N₃) ||
+            throw(SpaceMismatch("trace: A = $(space(A)),
+                    q1 = $(q₁), q2 = $(q₂)"))
     end
 
     if iszero(β)
@@ -37,8 +43,9 @@ function planartrace!(C::AbstractTensorMap{<:Number,S,N₁,N₂},
         rmul!(C, β)
     end
     for (f₁, f₂) in fusiontrees(A)
-        for ((f₁′, f₂′), coeff) in planar_trace(f₁, f₂, p..., q...)
-            TO.tensortrace!(C[f₁′, f₂′], p, A[f₁, f₂], q, :N, α * coeff, true, backend...)
+        for ((f₁′, f₂′), coeff) in planar_trace(f₁, f₂, p₁, p₂, q₁, q₂)
+            TO.tensortrace!(C[f₁′, f₂′], (p₁, p₂), A[f₁, f₂], (q₁, q₂), :N, α * coeff, true,
+                            backend...)
         end
     end
     return C

--- a/src/planar/planaroperations.jl
+++ b/src/planar/planaroperations.jl
@@ -8,13 +8,13 @@ function planaradd!(C::AbstractTensorMap,
     return add_transpose!(C, A, p, α, β, backend...)
 end
 
-function planartrace!(C::AbstractTensorMap{N₁,N₂},
-                      A::AbstractTensorMap,
+function planartrace!(C::AbstractTensorMap{<:Number,S,N₁,N₂},
+                      A::AbstractTensorMap{<:Number,S},
                       p::Index2Tuple{N₁,N₂},
                       q::Index2Tuple{N₃,N₃},
                       α::Number,
                       β::Number,
-                      backend::Backend...) where {N₁,N₂,N₃}
+                      backend::Backend...) where {S,N₁,N₂,N₃}
     if BraidingStyle(sectortype(S)) == Bosonic()
         return trace_permute!(C, A, p, q, α, β, backend...)
     end

--- a/src/tensors/abstracttensor.jl
+++ b/src/tensors/abstracttensor.jl
@@ -156,7 +156,7 @@ Return all indices of the domain of a tensor.
 See also [`codomainind`](@ref) and [`allind`](@ref).
 """
 function domainind(::Type{T}) where {T<:AbstractTensorMap}
-    return ntuple(n -> N₁ + n, N₂)
+    return ntuple(n -> numout(T) + n, numin(T))
 end
 domainind(t::AbstractTensorMap) = domainind(typeof(t))
 

--- a/src/tensors/abstracttensor.jl
+++ b/src/tensors/abstracttensor.jl
@@ -3,45 +3,45 @@
 # Abstract Tensor type
 #----------------------
 """
-    abstract type AbstractTensorMap{S<:IndexSpace, N₁, N₂} end
+    abstract type AbstractTensorMap{E<:Number, S<:IndexSpace, N₁, N₂} end
 
-Abstract supertype of all tensor maps, i.e. linear maps between tensor products
-of vector spaces of type `S<:IndexSpace`. An `AbstractTensorMap` maps from
-an input space of type `ProductSpace{S, N₂}` to an output space of type
-`ProductSpace{S, N₁}`.
+Abstract supertype of all tensor maps, i.e. linear maps between tensor products of vector
+spaces of type `S<:IndexSpace`, with element type `E`. An `AbstractTensorMap` maps from an
+input space of type `ProductSpace{S, N₂}` to an output space of type `ProductSpace{S, N₁}`.
 """
-abstract type AbstractTensorMap{S<:IndexSpace,N₁,N₂} end
-"""
-    AbstractTensor{S<:IndexSpace, N} = AbstractTensorMap{S, N, 0}
+abstract type AbstractTensorMap{E<:Number,S<:IndexSpace,N₁,N₂} end
 
-Abstract supertype of all tensors, i.e. elements in the tensor product space
-of type `ProductSpace{S, N}`, built from elementary spaces of type `S<:IndexSpace`.
-
-An `AbstractTensor{S, N}` is actually a special case `AbstractTensorMap{S, N, 0}`,
-i.e. a tensor map with only a non-trivial output space.
 """
-const AbstractTensor{S<:IndexSpace,N} = AbstractTensorMap{S,N,0}
+    AbstractTensor{E,S,N} = AbstractTensorMap{E,S,N,0}
+
+Abstract supertype of all tensors, i.e. elements in the tensor product space of type
+`ProductSpace{S, N}`, with element type `E`.
+
+An `AbstractTensor{E, S, N}` is actually a special case `AbstractTensorMap{E, S, N, 0}`,
+i.e. a tensor map with only non-trivial output spaces.
+"""
+const AbstractTensor{E,S,N} = AbstractTensorMap{E,S,N,0}
 
 # tensor characteristics
 #------------------------
-Base.eltype(::Union{T,Type{T}}) where {T<:AbstractTensorMap} = scalartype(T)
+Base.eltype(::Type{<:AbstractTensorMap{E}}) where {E} = E
 
 """
     spacetype(::Union{T,Type{T}}) where {T<:AbstractTensorMap} -> Type{S<:IndexSpace}
 
 Return the type of the elementary space `S` of a tensor.
 """
-spacetype(::Type{<:AbstractTensorMap{S}}) where {S<:IndexSpace} = S
+spacetype(::Type{<:AbstractTensorMap{E,S}}) where {E,S<:IndexSpace} = S
 
 """
     sectortype(::Union{T,Type{T}}) where {T<:AbstractTensorMap} -> Type{I<:Sector}
 
 Return the type of sector `I` of a tensor.
 """
-sectortype(::Type{<:AbstractTensorMap{S}}) where {S<:IndexSpace} = sectortype(S)
+sectortype(::Type{T}) where {T<:AbstractTensorMap} = sectortype(spacetype(T))
 
-function InnerProductStyle(::Type{<:AbstractTensorMap{S}}) where {S<:IndexSpace}
-    return InnerProductStyle(S)
+function InnerProductStyle(::Type{T}) where {T<:AbstractTensorMap}
+    return InnerProductStyle(spacetype(T))
 end
 
 """
@@ -49,7 +49,7 @@ end
 
 Return the type of field `𝕂` of a tensor.
 """
-field(::Type{<:AbstractTensorMap{S}}) where {S<:IndexSpace} = field(S)
+field(::Type{T}) where {T<:AbstractTensorMap} = field(spacetype(T))
 
 """
     numout(::Union{T,Type{T}}) where {T<:AbstractTensorMap} -> Int
@@ -58,7 +58,7 @@ Return the number of output spaces of a tensor. This is equivalent to the number
 
 See also [`numin`](@ref) and [`numind`](@ref).
 """
-numout(::Type{<:AbstractTensorMap{<:IndexSpace,N₁,N₂}}) where {N₁,N₂} = N₁
+numout(::Type{<:AbstractTensorMap{E,S,N₁}}) where {E,S,N₁} = N₁
 
 """
     numin(::Union{T,Type{T}}) where {T<:AbstractTensorMap} -> Int
@@ -67,7 +67,7 @@ Return the number of input spaces of a tensor. This is equivalent to the number 
 
 See also [`numout`](@ref) and [`numind`](@ref).
 """
-numin(::Type{<:AbstractTensorMap{<:IndexSpace,N₁,N₂}}) where {N₁,N₂} = N₂
+numin(::Type{<:AbstractTensorMap{E,S,N₁,N₂}}) where {E,S,N₁,N₂} = N₂
 
 """
     numind(::Union{T,Type{T}}) where {T<:AbstractTensorMap} -> Int
@@ -77,7 +77,7 @@ total number of spaces in the domain and codomain of that tensor.
 
 See also [`numout`](@ref) and [`numin`](@ref).
 """
-numind(::Type{<:AbstractTensorMap{<:IndexSpace,N₁,N₂}}) where {N₁,N₂} = N₁ + N₂
+numind(::Type{T}) where {T<:AbstractTensorMap} = numin(T) + numout(T)
 
 function similarstoragetype(TT::Type{<:AbstractTensorMap}, ::Type{T}) where {T}
     return Core.Compiler.return_type(similar, Tuple{storagetype(TT),Type{T}})
@@ -97,7 +97,7 @@ similarstoragetype(t::AbstractTensorMap, T) = similarstoragetype(typeof(t), T)
 const order = numind
 
 @doc """
-    codomain(t::AbstractTensorMap{S,N₁,N₂}, [i::Int]) -> ProductSpace{S,N₁}
+    codomain(t::AbstractTensorMap{E,S,N₁,N₂}, [i::Int]) -> ProductSpace{S,N₁}
 
 Return the codomain of a tensor, i.e. the product space of the output spaces. If `i` is
 specified, return the `i`-th output space. Implementations should provide `codomain(t)`.
@@ -109,7 +109,7 @@ codomain(t::AbstractTensorMap, i) = codomain(t)[i]
 target(t::AbstractTensorMap) = codomain(t) # categorical terminology
 
 @doc """
-    domain(t::AbstractTensorMap{S,N₁,N₂}, [i::Int]) -> ProductSpace{S,N₂}
+    domain(t::AbstractTensorMap{E,S,N₁,N₂}, [i::Int]) -> ProductSpace{S,N₂}
 
 Return the domain of a tensor, i.e. the product space of the input spaces. If `i` is
 specified, return the `i`-th input space. Implementations should provide `domain(t)`.
@@ -121,7 +121,7 @@ domain(t::AbstractTensorMap, i) = domain(t)[i]
 source(t::AbstractTensorMap) = domain(t) # categorical terminology
 
 """
-    space(t::AbstractTensorMap{S,N₁,N₂}, [i::Int]) -> HomSpace{S,N₁,N₂}
+    space(t::AbstractTensorMap{E,S,N₁,N₂}, [i::Int]) -> HomSpace{S,N₁,N₂}
 
 The index information of a tensor, i.e. the `HomSpace` of its domain and codomain. If `i` is specified, return the `i`-th index space.
 """
@@ -143,8 +143,8 @@ Return all indices of the codomain of a tensor.
 
 See also [`domainind`](@ref) and [`allind`](@ref).
 """
-function codomainind(::Type{<:AbstractTensorMap{<:IndexSpace,N₁,N₂}}) where {N₁,N₂}
-    return ntuple(n -> n, N₁)
+function codomainind(::Type{T}) where {T<:AbstractTensorMap}
+    return ntuple(identity, numout(T))
 end
 codomainind(t::AbstractTensorMap) = codomainind(typeof(t))
 
@@ -155,7 +155,7 @@ Return all indices of the domain of a tensor.
 
 See also [`codomainind`](@ref) and [`allind`](@ref).
 """
-function domainind(::Type{<:AbstractTensorMap{<:IndexSpace,N₁,N₂}}) where {N₁,N₂}
+function domainind(::Type{T}) where {T<:AbstractTensorMap}
     return ntuple(n -> N₁ + n, N₂)
 end
 domainind(t::AbstractTensorMap) = domainind(typeof(t))
@@ -167,13 +167,13 @@ Return all indices of a tensor, i.e. the indices of its domain and codomain.
 
 See also [`codomainind`](@ref) and [`domainind`](@ref).
 """
-function allind(::Type{<:AbstractTensorMap{<:IndexSpace,N₁,N₂}}) where {N₁,N₂}
-    return ntuple(n -> n, N₁ + N₂)
+function allind(::Type{T}) where {T<:AbstractTensorMap}
+    return ntuple(n -> n, numind(T))
 end
 allind(t::AbstractTensorMap) = allind(typeof(t))
 
-function adjointtensorindex(::AbstractTensorMap{<:IndexSpace,N₁,N₂}, i) where {N₁,N₂}
-    return ifelse(i <= N₁, N₂ + i, i - N₁)
+function adjointtensorindex(t::AbstractTensorMap, i)
+    return ifelse(i <= numout(t), numin(t) + i, i - numout(t))
 end
 
 function adjointtensorindices(t::AbstractTensorMap, indices::IndexTuple)
@@ -257,7 +257,7 @@ end
 # Conversion to Array:
 #----------------------
 # probably not optimized for speed, only for checking purposes
-function Base.convert(::Type{Array}, t::AbstractTensorMap{S,N₁,N₂}) where {S,N₁,N₂}
+function Base.convert(::Type{Array}, t::AbstractTensorMap)
     I = sectortype(t)
     if I === Trivial
         convert(Array, t[])

--- a/src/tensors/braidingtensor.jl
+++ b/src/tensors/braidingtensor.jl
@@ -224,14 +224,14 @@ function planaradd!(C::AbstractTensorMap,
     return planaradd!(C, copy(A), p, α, β, backend...)
 end
 
-function planarcontract!(C::AbstractTensorMap{<:Any,S,N₁,N₂},
-                         A::BraidingTensor{<:Any,S},
+function planarcontract!(C::AbstractTensorMap{<:Number,S,N₁,N₂},
+                         A::BraidingTensor{<:Number,S},
                          (oindA, cindA)::Index2Tuple{2,2},
-                         B::AbstractTensorMap{<:Any,S},
+                         B::AbstractTensorMap{<:Number,S},
                          (cindB, oindB)::Index2Tuple{2,N₃},
                          (p1, p2)::Index2Tuple{N₁,N₂},
                          α::Number, β::Number,
-                         backend::Backend...) where {S,N₁,N₂,N₃}
+                         backend::Backend...) where {S<:IndexSpace,N₁,N₂,N₃}
     codA, domA = codomainind(A), domainind(A)
     codB, domB = codomainind(B), domainind(B)
     oindA, cindA, oindB, cindB = reorder_indices(codA, domA, codB, domB, oindA, cindA,
@@ -270,14 +270,14 @@ function planarcontract!(C::AbstractTensorMap{<:Any,S,N₁,N₂},
     end
     return C
 end
-function planarcontract!(C::AbstractTensorMap{<:Any,S,N₁,N₂},
-                         A::AbstractTensorMap{<:Any,S},
+function planarcontract!(C::AbstractTensorMap{<:Number,S,N₁,N₂},
+                         A::AbstractTensorMap{<:Number,S},
                          (oindA, cindA)::Index2Tuple{N₃,2},
-                         B::BraidingTensor{<:Any,S},
+                         B::BraidingTensor{<:Number,S},
                          (cindB, oindB)::Index2Tuple{2,2},
                          (p1, p2)::Index2Tuple{N₁,N₂},
                          α::Number, β::Number,
-                         backend::Backend...) where {S,N₁,N₂,N₃}
+                         backend::Backend...) where {S<:IndexSpace,N₁,N₂,N₃}
     codA, domA = codomainind(A), domainind(A)
     codB, domB = codomainind(B), domainind(B)
     oindA, cindA, oindB, cindB = reorder_indices(codA, domA, codB, domB, oindA, cindA,
@@ -316,14 +316,14 @@ function planarcontract!(C::AbstractTensorMap{<:Any,S,N₁,N₂},
     end
     return C
 end
-function planarcontract!(C::AbstractTensorMap{<:Any,S,N₁,N₂},
-                         A::BraidingTensor{<:Any,S},
+function planarcontract!(C::AbstractTensorMap{<:Number,S,N₁,N₂},
+                         A::BraidingTensor{<:Number,S},
                          (oindA, cindA)::Index2Tuple{2,2},
-                         B::BraidingTensor{<:Any,S},
+                         B::BraidingTensor{<:Number,S},
                          (cindB, oindB)::Index2Tuple{2,2},
                          (p1, p2)::Index2Tuple{N₁,N₂},
                          α::Number, β::Number,
-                         backend::Backend...) where {S,N₁,N₂}
+                         backend::Backend...) where {S<:IndexSpace,N₁,N₂}
     return planarcontract!(C, copy(A), (oindA, cindA), B, (cindB, oindB), (p1, p2), α, β,
                            backend...)
 end

--- a/src/tensors/braidingtensor.jl
+++ b/src/tensors/braidingtensor.jl
@@ -35,7 +35,7 @@ function BraidingTensor(V1::S, V2::S, adjoint::Bool=false) where {S<:IndexSpace}
         return BraidingTensor{ComplexF64,S}(V1, V2, adjoint)
     end
 end
-function BraidingTensor(V::HomSpace{S}, adjoint::Bool=false) where {S<:IndexSpace}
+function BraidingTensor(V::HomSpace, adjoint::Bool=false)
     domain(V) == reverse(codomain(V)) ||
         throw(SpaceMismatch("Cannot define a braiding on $V"))
     return BraidingTensor(V[1], V[2], adjoint)

--- a/src/tensors/braidingtensor.jl
+++ b/src/tensors/braidingtensor.jl
@@ -337,12 +337,12 @@ function planarcontract!(C::AbstractTensorMap, A::BraidingTensor, pA::Index2Tupl
 end
 function planarcontract!(C::AbstractTensorMap, A::BraidingTensor, pA::Index2Tuple,
                          B::AbstractTensorMap, pB::Index2Tuple, α::Number, β::Number,
-                         backend::Backend...) 
+                         backend::Backend...)
     return planarcontract!(C, copy(A), pA, B, pB, α, β, backend...)
 end
 function planarcontract!(C::AbstractTensorMap, A::AbstractTensorMap, pA::Index2Tuple,
                          B::BraidingTensor, pB::Index2Tuple, α::Number, β::Number,
-                         backend::Backend...) 
+                         backend::Backend...)
     return planarcontract!(C, A, pA, copy(B), pB, α, β, backend...)
 end
 

--- a/src/tensors/braidingtensor.jl
+++ b/src/tensors/braidingtensor.jl
@@ -2,7 +2,7 @@
 # special (2,2) tensor that implements a standard braiding operation
 #====================================================================#
 """
-    struct BraidingTensor{S<:IndexSpace} <: AbstractTensorMap{S, 2, 2}
+    struct BraidingTensor{E,S<:IndexSpace} <: AbstractTensorMap{E, S, 2, 2}
     BraidingTensor(V1::S, V2::S, adjoint::Bool=false) where {S<:IndexSpace}
 
 Specific subtype of [`AbstractTensorMap`](@ref) for representing the braiding tensor that
@@ -11,12 +11,11 @@ braids the first input over the second input; its inverse can be obtained as the
 It holds that `domain(BraidingTensor(V1, V2)) == V1 ⊗ V2` and
 `codomain(BraidingTensor(V1, V2)) == V2 ⊗ V1`.
 """
-struct BraidingTensor{S<:IndexSpace,A} <: AbstractTensorMap{S,2,2}
+struct BraidingTensor{E,S} <: AbstractTensorMap{E,S,2,2}
     V1::S
     V2::S
     adjoint::Bool
-    function BraidingTensor{S,A}(V1::S, V2::S,
-                                 adjoint::Bool=false) where {S<:IndexSpace,A<:DenseMatrix}
+    function BraidingTensor{E,S}(V1::S, V2::S, adjoint::Bool=false) where {E,S<:IndexSpace}
         for a in sectors(V1)
             for b in sectors(V2)
                 for c in (a ⊗ b)
@@ -25,15 +24,15 @@ struct BraidingTensor{S<:IndexSpace,A} <: AbstractTensorMap{S,2,2}
                 end
             end
         end
-        return new{S,A}(V1, V2, adjoint)
+        return new{E,S}(V1, V2, adjoint)
         # partial construction: only construct rowr and colr when needed
     end
 end
 function BraidingTensor(V1::S, V2::S, adjoint::Bool=false) where {S<:IndexSpace}
     if BraidingStyle(sectortype(S)) isa SymmetricBraiding
-        return BraidingTensor{S,Matrix{Float64}}(V1, V2, adjoint)
+        return BraidingTensor{Float64,S}(V1, V2, adjoint)
     else
-        return BraidingTensor{S,Matrix{ComplexF64}}(V1, V2, adjoint)
+        return BraidingTensor{ComplexF64,S}(V1, V2, adjoint)
     end
 end
 function BraidingTensor(V::HomSpace{S}, adjoint::Bool=false) where {S<:IndexSpace}
@@ -41,14 +40,15 @@ function BraidingTensor(V::HomSpace{S}, adjoint::Bool=false) where {S<:IndexSpac
         throw(SpaceMismatch("Cannot define a braiding on $V"))
     return BraidingTensor(V[1], V[2], adjoint)
 end
-function Base.adjoint(b::BraidingTensor{S,A}) where {S<:IndexSpace,A<:DenseMatrix}
-    return BraidingTensor{S,A}(b.V1, b.V2, !b.adjoint)
+function Base.adjoint(b::BraidingTensor{E,S}) where {E,S}
+    return BraidingTensor{E,S}(b.V1, b.V2, !b.adjoint)
 end
 
 domain(b::BraidingTensor) = b.adjoint ? b.V2 ⊗ b.V1 : b.V1 ⊗ b.V2
 codomain(b::BraidingTensor) = b.adjoint ? b.V1 ⊗ b.V2 : b.V2 ⊗ b.V1
 
-storagetype(::Type{BraidingTensor{S,A}}) where {S<:IndexSpace,A<:DenseMatrix} = A
+# TODO: check if this can be removed/is correct
+storagetype(::Type{BraidingTensor{E,S}}) where {E,S} = Matrix{E}
 
 blocksectors(b::BraidingTensor) = blocksectors(b.V1 ⊗ b.V2)
 hasblock(b::BraidingTensor, s::Sector) = s ∈ blocksectors(b)
@@ -87,8 +87,8 @@ function fusiontrees(b::BraidingTensor)
     return TensorKeyIterator(rowr, colr)
 end
 
-function Base.getindex(b::BraidingTensor{S}) where {S}
-    sectortype(S) == Trivial || throw(SectorMismatch())
+function Base.getindex(b::BraidingTensor)
+    sectortype(b) === Trivial || throw(SectorMismatch())
     (V1, V2) = domain(b)
     d = (dim(V2), dim(V1), dim(V1), dim(V2))
     return sreshape(StridedView(block(b, Trivial())), d)
@@ -192,13 +192,13 @@ blocks(b::BraidingTensor) = blocks(TensorMap(b))
 # Index manipulations
 # -------------------
 has_shared_permute(t::BraidingTensor, args...) = false
-function add_transform!(tdst::AbstractTensorMap{S,N₁,N₂},
-                        tsrc::BraidingTensor{S},
-                        (p₁, p₂)::Index2Tuple{N₁,N₂},
+function add_transform!(tdst::AbstractTensorMap,
+                        tsrc::BraidingTensor,
+                        (p₁, p₂)::Index2Tuple,
                         fusiontreetransform,
                         α::Number,
                         β::Number,
-                        backend::Backend...) where {S,N₁,N₂}
+                        backend::Backend...)
     return add_transform!(tdst, copy(tsrc), (p₁, p₂), fusiontreetransform, α, β, backend...)
 end
 
@@ -209,26 +209,25 @@ end
 # TensorOperations
 # ----------------
 # TODO: implement specialized methods
-function TO.tensoradd!(C::AbstractTensorMap{S,N₁,N₂}, pC::Index2Tuple{N₁,N₂},
-                       A::BraidingTensor{S}, conjA::Symbol, α::Number, β::Number,
-                       backend::Backend...) where {S,N₁,N₂}
+function TO.tensoradd!(C::AbstractTensorMap, pC::Index2Tuple,
+                       A::BraidingTensor, conjA::Symbol, α::Number, β::Number,
+                       backend::Backend...)
     return TO.tensoradd!(C, pC, copy(A), conjA, α, β, backend...)
 end
 
 # Planar operations
 # -----------------
-function planaradd!(C::AbstractTensorMap{S,N₁,N₂},
-                    A::BraidingTensor{S},
-                    p::Index2Tuple{N₁,N₂},
+function planaradd!(C::AbstractTensorMap,
+                    A::BraidingTensor, p::Index2Tuple,
                     α::Number, β::Number,
-                    backend::Backend...) where {S,N₁,N₂}
+                    backend::Backend...)
     return planaradd!(C, copy(A), p, α, β, backend...)
 end
 
-function planarcontract!(C::AbstractTensorMap{S,N₁,N₂},
-                         A::BraidingTensor{S},
+function planarcontract!(C::AbstractTensorMap{<:Any,S,N₁,N₂},
+                         A::BraidingTensor{<:Any,S},
                          (oindA, cindA)::Index2Tuple{2,2},
-                         B::AbstractTensorMap{S},
+                         B::AbstractTensorMap{<:Any,S},
                          (cindB, oindB)::Index2Tuple{2,N₃},
                          (p1, p2)::Index2Tuple{N₁,N₂},
                          α::Number, β::Number,
@@ -271,10 +270,10 @@ function planarcontract!(C::AbstractTensorMap{S,N₁,N₂},
     end
     return C
 end
-function planarcontract!(C::AbstractTensorMap{S,N₁,N₂},
-                         A::AbstractTensorMap{S},
+function planarcontract!(C::AbstractTensorMap{<:Any,S,N₁,N₂},
+                         A::AbstractTensorMap{<:Any,S},
                          (oindA, cindA)::Index2Tuple{N₃,2},
-                         B::BraidingTensor{S},
+                         B::BraidingTensor{<:Any,S},
                          (cindB, oindB)::Index2Tuple{2,2},
                          (p1, p2)::Index2Tuple{N₁,N₂},
                          α::Number, β::Number,
@@ -317,10 +316,10 @@ function planarcontract!(C::AbstractTensorMap{S,N₁,N₂},
     end
     return C
 end
-function planarcontract!(C::AbstractTensorMap{S,N₁,N₂},
-                         A::BraidingTensor{S},
+function planarcontract!(C::AbstractTensorMap{<:Any,S,N₁,N₂},
+                         A::BraidingTensor{<:Any,S},
                          (oindA, cindA)::Index2Tuple{2,2},
-                         B::BraidingTensor{S},
+                         B::BraidingTensor{<:Any,S},
                          (cindB, oindB)::Index2Tuple{2,2},
                          (p1, p2)::Index2Tuple{N₁,N₂},
                          α::Number, β::Number,
@@ -331,27 +330,27 @@ end
 
 # Fallback cases for planarcontract!
 # TODO: implement specialised cases for contracting 0, 1, 3 and 4 indices
-function planarcontract!(C::AbstractTensorMap{S}, A::BraidingTensor{S}, pA::Index2Tuple,
-                         B::BraidingTensor{S}, pB::Index2Tuple, α::Number, β::Number,
-                         backend::Backend...) where {S}
+function planarcontract!(C::AbstractTensorMap, A::BraidingTensor, pA::Index2Tuple,
+                         B::BraidingTensor, pB::Index2Tuple, α::Number, β::Number,
+                         backend::Backend...)
     return planarcontract!(C, copy(A), pA, copy(B), pB, α, β, backend...)
 end
-function planarcontract!(C::AbstractTensorMap{S}, A::BraidingTensor{S}, pA::Index2Tuple,
-                         B::AbstractTensorMap{S}, pB::Index2Tuple, α::Number, β::Number,
-                         backend::Backend...) where {S}
+function planarcontract!(C::AbstractTensorMap, A::BraidingTensor, pA::Index2Tuple,
+                         B::AbstractTensorMap, pB::Index2Tuple, α::Number, β::Number,
+                         backend::Backend...) 
     return planarcontract!(C, copy(A), pA, B, pB, α, β, backend...)
 end
-function planarcontract!(C::AbstractTensorMap{S}, A::AbstractTensorMap{S}, pA::Index2Tuple,
-                         B::BraidingTensor{S}, pB::Index2Tuple, α::Number, β::Number,
-                         backend::Backend...) where {S}
+function planarcontract!(C::AbstractTensorMap, A::AbstractTensorMap, pA::Index2Tuple,
+                         B::BraidingTensor, pB::Index2Tuple, α::Number, β::Number,
+                         backend::Backend...) 
     return planarcontract!(C, A, pA, copy(B), pB, α, β, backend...)
 end
 
-function planartrace!(C::AbstractTensorMap{S,N₁,N₂},
-                      A::BraidingTensor{S},
-                      p::Index2Tuple{N₁,N₂}, q::Index2Tuple{N₃,N₃},
+function planartrace!(C::AbstractTensorMap,
+                      A::BraidingTensor,
+                      p::Index2Tuple, q::Index2Tuple,
                       α::Number, β::Number,
-                      backend::Backend...) where {S,N₁,N₂,N₃}
+                      backend::Backend...)
     return planartrace!(C, copy(A), p, q, α, β, backend...)
 end
 

--- a/src/tensors/indexmanipulations.jl
+++ b/src/tensors/indexmanipulations.jl
@@ -1,8 +1,7 @@
 # Index manipulations
 #---------------------
 """
-    permute!(tdst::AbstractTensorMap{S,N₁,N₂}, tsrc::AbstractTensorMap{S},
-             (p₁, p₂)::Tuple{IndexTuple{N₁},IndexTuple{N₂}}) where {S,N₁,N₂}
+    permute!(tdst::AbstractTensorMap, tsrc::AbstractTensorMap, (p₁, p₂)::Index2Tuple)
         -> tdst
 
 Write into `tdst` the result of permuting the indices of `tsrc`.
@@ -10,16 +9,16 @@ The codomain and domain of `tdst` correspond to the indices in `p₁` and `p₂`
                 
 See [`permute`](@ref) for creating a new tensor and [`add_permute!`](@ref) for a more general version.
 """
-@propagate_inbounds function Base.permute!(tdst::AbstractTensorMap{S,N₁,N₂},
-                                           tsrc::AbstractTensorMap{S},
-                                           p::Index2Tuple{N₁,N₂}) where {S,N₁,N₂}
+@propagate_inbounds function Base.permute!(tdst::AbstractTensorMap,
+                                           tsrc::AbstractTensorMap,
+                                           p::Index2Tuple)
     return add_permute!(tdst, tsrc, p, true, false)
 end
 
 """
-    permute(tsrc::AbstractTensorMap{S}, (p₁, p₂)::Tuple{IndexTuple{N₁},IndexTuple{N₂}};
-            copy::Bool=false) where {S,N₁,N₂}
-        -> tdst::TensorMap{S,N₁,N₂}
+    permute(tsrc::AbstractTensorMap, (p₁, p₂)::Index2Tuple;
+            copy::Bool=false)
+        -> tdst::TensorMap
 
 Return tensor `tdst` obtained by permuting the indices of `tsrc`.
 The codomain and domain of `tdst` correspond to the indices in `p₁` and `p₂` of `tsrc` respectively.
@@ -28,10 +27,10 @@ If `copy=false`, `tdst` might share data with `tsrc` whenever possible. Otherwis
 
 To permute into an existing destination, see [permute!](@ref) and [`add_permute!`](@ref)
 """
-function permute(t::AbstractTensorMap{S}, (p₁, p₂)::Index2Tuple{N₁,N₂};
-                 copy::Bool=false) where {S,N₁,N₂}
-    cod = ProductSpace{S,N₁}(map(n -> space(t, n), p₁))
-    dom = ProductSpace{S,N₂}(map(n -> dual(space(t, n)), p₂))
+function permute(t::AbstractTensorMap, (p₁, p₂)::Index2Tuple{N₁,N₂};
+                 copy::Bool=false) where {N₁,N₂}
+    cod = ProductSpace{spacetype(t),N₁}(map(n -> space(t, n), p₁))
+    dom = ProductSpace{spacetype(t),N₂}(map(n -> dual(space(t, n)), p₂))
     # share data if possible
     if !copy
         if p₁ === codomainind(t) && p₂ === domainind(t)
@@ -45,14 +44,13 @@ function permute(t::AbstractTensorMap{S}, (p₁, p₂)::Index2Tuple{N₁,N₂};
         return permute!(similar(t, cod ← dom), t, (p₁, p₂))
     end
 end
-function permute(t::AdjointTensorMap{S}, (p₁, p₂)::Index2Tuple;
-                 copy::Bool=false) where {S}
+function permute(t::AdjointTensorMap, (p₁, p₂)::Index2Tuple; copy::Bool=false)
     p₁′ = adjointtensorindices(t, p₂)
     p₂′ = adjointtensorindices(t, p₁)
-    return adjoint(permute(adjoint(t), (p₁′, p₂′); copy=copy))
+    return adjoint(permute(adjoint(t), (p₁′, p₂′); copy))
 end
 function permute(t::AbstractTensorMap, p::IndexTuple; copy::Bool=false)
-    return permute(t, (p, ()); copy=copy)
+    return permute(t, (p, ()); copy)
 end
 
 function has_shared_permute(t::TensorMap, (p₁, p₂)::Index2Tuple)
@@ -76,8 +74,8 @@ end
 
 # Braid
 """
-    braid!(tdst::AbstractTensorMap{S,N₁,N₂}, tsrc::AbstractTensorMap{S},
-           (p₁, p₂)::Tuple{IndexTuple{N₁},IndexTuple{N₂}}, levels::Tuple) where {S,N₁,N₂}
+    braid!(tdst::AbstractTensorMap, tsrc::AbstractTensorMap,
+           (p₁, p₂)::Index2Tuple, levels::Tuple)
         -> tdst
 
 Write into `tdst` the result of braiding the indices of `tsrc`.
@@ -87,17 +85,17 @@ which determines whether they will braid over or under any other index with whic
 
 See [`braid`](@ref) for creating a new tensor and [`add_braid!`](@ref) for a more general version.
 """
-@propagate_inbounds function braid!(tdst::AbstractTensorMap{S,N₁,N₂},
-                                    tsrc::AbstractTensorMap{S},
-                                    (p₁, p₂)::Index2Tuple{N₁,N₂},
-                                    levels::IndexTuple) where {S,N₁,N₂}
-    return add_braid!(tdst, tsrc, (p₁, p₂), levels, true, false)
+@propagate_inbounds function braid!(tdst::AbstractTensorMap,
+                                    tsrc::AbstractTensorMap,
+                                    p::Index2Tuple,
+                                    levels::IndexTuple)
+    return add_braid!(tdst, tsrc, p, levels, true, false)
 end
 
 """
-    braid(tsrc::AbstractTensorMap{S}, (p₁, p₂)::Tuple{IndexTuple{N₁},IndexTuple{N₂}}, levels::Tuple;
-          copy::Bool = false) where {S,N₁,N₂}
-        -> tdst::TensorMap{S,N₁,N₂}
+    braid(tsrc::AbstractTensorMap, (p₁, p₂)::Index2Tuple, levels::IndexTuple;
+          copy::Bool = false)
+        -> tdst::TensorMap
 
 Return tensor `tdst` obtained by braiding the indices of `tsrc`.
 The codomain and domain of `tdst` correspond to the indices in `p₁` and `p₂` of `tsrc` respectively.
@@ -108,18 +106,18 @@ If `copy=false`, `tdst` might share data with `tsrc` whenever possible. Otherwis
 
 To braid into an existing destination, see [braid!](@ref) and [`add_braid!`](@ref)
 """
-function braid(t::AbstractTensorMap{S}, (p₁, p₂)::Index2Tuple, levels::IndexTuple;
-               copy::Bool=false) where {S}
+function braid(t::AbstractTensorMap, (p₁, p₂)::Index2Tuple, levels::IndexTuple;
+               copy::Bool=false)
     @assert length(levels) == numind(t)
-    if BraidingStyle(sectortype(S)) isa SymmetricBraiding
+    if BraidingStyle(sectortype(t)) isa SymmetricBraiding
         return permute(t, (p₁, p₂); copy=copy)
     end
     if !copy && p₁ == codomainind(t) && p₂ == domainind(t)
         return t
     end
     # general case
-    cod = ProductSpace{S}(map(n -> space(t, n), p₁))
-    dom = ProductSpace{S}(map(n -> dual(space(t, n)), p₂))
+    cod = ProductSpace{spacetype(t)}(map(n -> space(t, n), p₁))
+    dom = ProductSpace{spacetype(t)}(map(n -> dual(space(t, n)), p₂))
     @inbounds begin
         return braid!(similar(t, cod ← dom), t, (p₁, p₂), levels)
     end
@@ -130,8 +128,8 @@ end
 _transpose_indices(t::AbstractTensorMap) = (reverse(domainind(t)), reverse(codomainind(t)))
 
 """
-    transpose!(tdst::AbstractTensorMap{S,N₁,N₂}, tsrc::AbstractTensorMap{S},
-               (p₁, p₂)::Tuple{IndexTuple{N₁},IndexTuple{N₂}}) where {S,N₁,N₂}
+    transpose!(tdst::AbstractTensorMap, tsrc::AbstractTensorMap,
+               (p₁, p₂)::Index2Tuple)
         -> tdst
 
 Write into `tdst` the result of transposing the indices of `tsrc`.
@@ -148,9 +146,9 @@ function LinearAlgebra.transpose!(tdst::AbstractTensorMap,
 end
 
 """
-    transpose(tsrc::AbstractTensorMap{S}, (p₁, p₂)::Tuple{IndexTuple{N₁},IndexTuple{N₂}};
-              copy::Bool=false) where {S,N₁,N₂}
-        -> tdst::TensorMap{S,N₁,N₂}
+    transpose(tsrc::AbstractTensorMap, (p₁, p₂)::Index2Tuple;
+              copy::Bool=false)
+        -> tdst::TensorMap
 
 Return tensor `tdst` obtained by transposing the indices of `tsrc`.
 The codomain and domain of `tdst` correspond to the indices in `p₁` and `p₂` of `tsrc` respectively.
@@ -161,26 +159,26 @@ If `copy=false`, `tdst` might share data with `tsrc` whenever possible. Otherwis
 
 To permute into an existing destination, see [permute!](@ref) and [`add_permute!`](@ref)
 """
-function LinearAlgebra.transpose(t::AbstractTensorMap{S},
+function LinearAlgebra.transpose(t::AbstractTensorMap,
                                  (p₁, p₂)::Index2Tuple=_transpose_indices(t);
-                                 copy::Bool=false) where {S}
-    if sectortype(S) === Trivial
+                                 copy::Bool=false)
+    if sectortype(t) === Trivial
         return permute(t, (p₁, p₂); copy=copy)
     end
     if !copy && p₁ == codomainind(t) && p₂ == domainind(t)
         return t
     end
     # general case
-    cod = ProductSpace{S}(map(n -> space(t, n), p₁))
-    dom = ProductSpace{S}(map(n -> dual(space(t, n)), p₂))
+    cod = ProductSpace{spacetype(t)}(map(n -> space(t, n), p₁))
+    dom = ProductSpace{spacetype(t)}(map(n -> dual(space(t, n)), p₂))
     @inbounds begin
         return transpose!(similar(t, cod ← dom), t, (p₁, p₂))
     end
 end
 
-function LinearAlgebra.transpose(t::AdjointTensorMap{S},
+function LinearAlgebra.transpose(t::AdjointTensorMap,
                                  (p₁, p₂)::Index2Tuple=_transpose_indices(t);
-                                 copy::Bool=false) where {S}
+                                 copy::Bool=false)
     p₁′ = map(n -> adjointtensorindex(t, n), p₂)
     p₂′ = map(n -> adjointtensorindex(t, n), p₁)
     return adjoint(transpose(adjoint(t), (p₁′, p₂′); copy=copy))
@@ -228,23 +226,23 @@ twist(t::AbstractTensorMap, i::Int; inv::Bool=false) = twist!(copy(t), i; inv=in
 #-------------------------------------
 # Full implementations based on `add`
 #-------------------------------------
-@propagate_inbounds function add_permute!(tdst::AbstractTensorMap{S,N₁,N₂},
+@propagate_inbounds function add_permute!(tdst::AbstractTensorMap{E,S,N₁,N₂},
                                           tsrc::AbstractTensorMap,
                                           p::Index2Tuple{N₁,N₂},
                                           α::Number,
                                           β::Number,
-                                          backend::Backend...) where {S,N₁,N₂}
+                                          backend::Backend...) where {E,S,N₁,N₂}
     treepermuter(f₁, f₂) = permute(f₁, f₂, p[1], p[2])
     return add_transform!(tdst, tsrc, p, treepermuter, α, β, backend...)
 end
 
-@propagate_inbounds function add_braid!(tdst::AbstractTensorMap{S,N₁,N₂},
+@propagate_inbounds function add_braid!(tdst::AbstractTensorMap{E,S,N₁,N₂},
                                         tsrc::AbstractTensorMap,
                                         p::Index2Tuple{N₁,N₂},
                                         levels::IndexTuple,
                                         α::Number,
                                         β::Number,
-                                        backend::Backend...) where {S,N₁,N₂}
+                                        backend::Backend...) where {E,S,N₁,N₂}
     length(levels) == numind(tsrc) ||
         throw(ArgumentError("incorrect levels $levels for tensor map $(codomain(tsrc)) ← $(domain(tsrc))"))
 
@@ -255,23 +253,23 @@ end
     return add_transform!(tdst, tsrc, p, treebraider, α, β, backend...)
 end
 
-@propagate_inbounds function add_transpose!(tdst::AbstractTensorMap{S,N₁,N₂},
+@propagate_inbounds function add_transpose!(tdst::AbstractTensorMap{E,S,N₁,N₂},
                                             tsrc::AbstractTensorMap,
                                             p::Index2Tuple{N₁,N₂},
                                             α::Number,
                                             β::Number,
-                                            backend::Backend...) where {S,N₁,N₂}
+                                            backend::Backend...) where {E,S,N₁,N₂}
     treetransposer(f₁, f₂) = transpose(f₁, f₂, p[1], p[2])
     return add_transform!(tdst, tsrc, p, treetransposer, α, β, backend...)
 end
 
-function add_transform!(tdst::AbstractTensorMap{S,N₁,N₂},
+function add_transform!(tdst::AbstractTensorMap{E,S,N₁,N₂},
                         tsrc::AbstractTensorMap,
                         (p₁, p₂)::Index2Tuple{N₁,N₂},
                         fusiontreetransform,
                         α::Number,
                         β::Number,
-                        backend::Backend...) where {S,N₁,N₂}
+                        backend::Backend...) where {E,S,N₁,N₂}
     @boundscheck begin
         all(i -> space(tsrc, p₁[i]) == space(tdst, i), 1:N₁) ||
             throw(SpaceMismatch("source = $(codomain(tsrc))←$(domain(tsrc)),

--- a/src/tensors/linalg.jl
+++ b/src/tensors/linalg.jl
@@ -383,8 +383,7 @@ for f in (:sqrt, :log, :asin, :acos, :acosh, :atanh, :acoth)
 end
 
 # concatenate tensors
-function catdomain(t1::AbstractTensorMap{<:Any,S,N₁,1},
-                   t2::AbstractTensorMap{<:Any,S,N₁,1}) where {S,N₁}
+function catdomain(t1::T, t2::T) where {S,N₁,T<:AbstractTensorMap{<:Any,S,N₁,1}}
     codomain(t1) == codomain(t2) ||
         throw(SpaceMismatch("codomains of tensors to concatenate must match:\n" *
                             "$(codomain(t1)) ≠ $(codomain(t2))"))
@@ -401,8 +400,7 @@ function catdomain(t1::AbstractTensorMap{<:Any,S,N₁,1},
     end
     return t
 end
-function catcodomain(t1::AbstractTensorMap{<:Any,S,1,N₂},
-                     t2::AbstractTensorMap{<:Any,S,1,N₂}) where {S,N₂}
+function catcodomain(t1::T, t2::T) where {S,N₂,T<:AbstractTensorMap{<:Any,S,1,N₂}}
     domain(t1) == domain(t2) ||
         throw(SpaceMismatch("domains of tensors to concatenate must match:\n" *
                             "$(domain(t1)) ≠ $(domain(t2))"))
@@ -428,7 +426,9 @@ Compute the tensor product between two `AbstractTensorMap` instances, which resu
 new `TensorMap` instance whose codomain is `codomain(t1) ⊗ codomain(t2)` and whose domain
 is `domain(t1) ⊗ domain(t2)`.
 """
-function ⊗(t1::AbstractTensorMap{<:Any,S}, t2::AbstractTensorMap{<:Any,S}) where {S}
+function ⊗(t1::AbstractTensorMap, t2::AbstractTensorMap)
+    (S = spacetype(t1)) === spacetype(t2) ||
+        throw(SpaceMismatch("spacetype(t1) ≠ spacetype(t2)"))
     cod1, cod2 = codomain(t1), codomain(t2)
     dom1, dom2 = domain(t1), domain(t2)
     cod = cod1 ⊗ cod2

--- a/src/tensors/linalg.jl
+++ b/src/tensors/linalg.jl
@@ -164,8 +164,8 @@ function Base.fill!(t::AbstractTensorMap, value::Number)
     end
     return t
 end
-function LinearAlgebra.adjoint!(tdst::AbstractTensorMap{S},
-                                tsrc::AbstractTensorMap{S}) where {S}
+function LinearAlgebra.adjoint!(tdst::AbstractTensorMap,
+                                tsrc::AbstractTensorMap)
     InnerProductStyle(tdst) === EuclideanProduct() || throw_invalid_innerproduct(:adjoint!)
     space(tdst) == adjoint(space(tsrc)) ||
         throw(SpaceMismatch("$(space(tdst)) ≠ adjoint($(space(tsrc)))"))
@@ -383,8 +383,8 @@ for f in (:sqrt, :log, :asin, :acos, :acosh, :atanh, :acoth)
 end
 
 # concatenate tensors
-function catdomain(t1::AbstractTensorMap{S,N₁,1},
-                   t2::AbstractTensorMap{S,N₁,1}) where {S,N₁}
+function catdomain(t1::AbstractTensorMap{<:Any.S,N₁,1},
+                   t2::AbstractTensorMap{<:Any,S,N₁,1}) where {S,N₁}
     codomain(t1) == codomain(t2) ||
         throw(SpaceMismatch("codomains of tensors to concatenate must match:\n" *
                             "$(codomain(t1)) ≠ $(codomain(t2))"))
@@ -401,8 +401,8 @@ function catdomain(t1::AbstractTensorMap{S,N₁,1},
     end
     return t
 end
-function catcodomain(t1::AbstractTensorMap{S,1,N₂},
-                     t2::AbstractTensorMap{S,1,N₂}) where {S,N₂}
+function catcodomain(t1::AbstractTensorMap{<:Any,S,1,N₂},
+                     t2::AbstractTensorMap{<:Any,S,1,N₂}) where {S,N₂}
     domain(t1) == domain(t2) ||
         throw(SpaceMismatch("domains of tensors to concatenate must match:\n" *
                             "$(domain(t1)) ≠ $(domain(t2))"))
@@ -422,13 +422,13 @@ end
 
 # tensor product of tensors
 """
-    ⊗(t1::AbstractTensorMap{S}, t2::AbstractTensorMap{S}, ...) -> TensorMap{S}
+    ⊗(t1::AbstractTensorMap, t2::AbstractTensorMap, ...) -> TensorMap
 
 Compute the tensor product between two `AbstractTensorMap` instances, which results in a
 new `TensorMap` instance whose codomain is `codomain(t1) ⊗ codomain(t2)` and whose domain
 is `domain(t1) ⊗ domain(t2)`.
 """
-function ⊗(t1::AbstractTensorMap{S}, t2::AbstractTensorMap{S}) where {S}
+function ⊗(t1::AbstractTensorMap{<:Any,S}, t2::AbstractTensorMap{<:Any,S}) where {S}
     cod1, cod2 = codomain(t1), codomain(t2)
     dom1, dom2 = domain(t1), domain(t2)
     cod = cod1 ⊗ cod2

--- a/src/tensors/linalg.jl
+++ b/src/tensors/linalg.jl
@@ -383,7 +383,7 @@ for f in (:sqrt, :log, :asin, :acos, :acosh, :atanh, :acoth)
 end
 
 # concatenate tensors
-function catdomain(t1::AbstractTensorMap{<:Any.S,N₁,1},
+function catdomain(t1::AbstractTensorMap{<:Any,S,N₁,1},
                    t2::AbstractTensorMap{<:Any,S,N₁,1}) where {S,N₁}
     codomain(t1) == codomain(t2) ||
         throw(SpaceMismatch("codomains of tensors to concatenate must match:\n" *

--- a/src/tensors/tensor.jl
+++ b/src/tensors/tensor.jl
@@ -52,7 +52,8 @@ const Tensor{E,S,N,I,A,F₁,F₂} = TensorMap{E,S,N,0,I,A,F₁,F₂}
 A special case of [`TensorMap`](@ref) for representing tensor maps with trivial symmetry,
 i.e., whose `sectortype` is `Trivial`.
 """
-const TrivialTensorMap{E,S,N₁,N₂,A<:DenseMatrix} = TensorMap{E,S,N₁,N₂,Trivial,A, Nothing,Nothing}
+const TrivialTensorMap{E,S,N₁,N₂,A<:DenseMatrix} = TensorMap{E,S,N₁,N₂,Trivial,A,Nothing,
+                                                             Nothing}
 
 """
     TrivialTensor{E, S, N, A} = TrivialTensorMap{E, S, N, 0, A}
@@ -512,7 +513,8 @@ end
 @propagate_inbounds function Base.setindex!(t::TensorMap{E,S,N₁,N₂,I},
                                             v,
                                             f₁::FusionTree{I,N₁},
-                                            f₂::FusionTree{I,N₂}) where {E,S,N₁,N₂,I<:Sector}
+                                            f₂::FusionTree{I,N₂}) where {E,S,N₁,N₂,
+                                                                         I<:Sector}
     return copy!(getindex(t, f₁, f₂), v)
 end
 

--- a/src/tensors/tensor.jl
+++ b/src/tensors/tensor.jl
@@ -40,7 +40,7 @@ end
 Specific subtype of [`AbstractTensor`](@ref) for representing tensors whose data is stored
 in blocks of some subtype of `DenseMatrix`.
 
-A `Tensor{S, N, I, A, F₁, F₂}` is actually a special case `TensorMap{S, N, 0, I, A, F₁, F₂}`,
+A `Tensor{E, S, N, I, A, F₁, F₂}` is actually a special case `TensorMap{E, S, N, 0, I, A, F₁, F₂}`,
 i.e. a tensor map with only a non-trivial output space.
 """
 const Tensor{E,S,N,I,A,F₁,F₂} = TensorMap{E,S,N,0,I,A,F₁,F₂}
@@ -352,7 +352,7 @@ Base.similar(t::AbstractTensorMap, T::Type) = similar(t, T, space(t))
 Base.similar(t::AbstractTensorMap) = similar(t, scalartype(t), space(t))
 
 # actual implementation
-function Base.similar(t::TensorMap{S}, ::Type{T}, P::TensorMapSpace{S}) where {T,S}
+function Base.similar(t::TensorMap, ::Type{T}, P::TensorMapSpace{S}) where {T,S}
     N₁ = length(codomain(P))
     N₂ = length(domain(P))
     I = sectortype(S)

--- a/src/tensors/tensor.jl
+++ b/src/tensors/tensor.jl
@@ -474,8 +474,8 @@ blocks(t::TensorMap) = t.data
 fusiontrees(t::TrivialTensorMap) = ((nothing, nothing),)
 fusiontrees(t::TensorMap) = TensorKeyIterator(t.rowr, t.colr)
 
-@inline function Base.getindex(t::TensorMap{E,S,N₁,N₂,I},
-                               sectors::Tuple{Vararg{I}}) where {E,S,N₁,N₂,I<:Sector}
+@inline function Base.getindex(t::TensorMap, sectors::Tuple{I,Vararg{I}}) where {I<:Sector}
+    I === sectortype(t) || throw(SectorMismatch("Not a valid sectortype for this tensor."))
     FusionStyle(I) isa UniqueFusion ||
         throw(SectorMismatch("Indexing with sectors only possible if unique fusion"))
     s1 = TupleTools.getindices(sectors, codomainind(t))

--- a/src/tensors/tensoroperations.jl
+++ b/src/tensors/tensoroperations.jl
@@ -171,9 +171,9 @@ function trace_permute!(tdst::AbstractTensorMap,
     end
     (N₃ = length(q₁)) == length(q₂) ||
         throw(IndexError("number of trace indices does not match"))
-    
+
     N₁, N₂ = length(p₁), length(p₂)
-    
+
     @boundscheck begin
         numout(tdst) == N₁ || throw(IndexError("number of output indices does not match"))
         numin(tdst) == N₂ || throw(IndexError("number of input indices does not match"))
@@ -238,7 +238,7 @@ function contract!(C::AbstractTensorMap,
     length(cindA) == length(cindB) ||
         throw(IndexError("number of contracted indices does not match"))
     N₁, N₂ = length(oindA), length(oindB)
-    
+
     # find optimal contraction scheme
     hsp = has_shared_permute
     ipC = TupleTools.invperm((p₁..., p₂...))

--- a/src/tensors/tensoroperations.jl
+++ b/src/tensors/tensoroperations.jl
@@ -292,7 +292,7 @@ function _contract!(α, A::AbstractTensorMap, B::AbstractTensorMap,
                     oindA::IndexTuple, cindA::IndexTuple,
                     oindB::IndexTuple, cindB::IndexTuple,
                     p₁::IndexTuple, p₂::IndexTuple)
-    if !(BraidingStyle(sectortype(S)) isa SymmetricBraiding)
+    if !(BraidingStyle(sectortype(C)) isa SymmetricBraiding)
         throw(SectorMismatch("only tensors with symmetric braiding rules can be contracted; try `@planar` instead"))
     end
     N₁, N₂ = length(oindA), length(oindB)
@@ -306,7 +306,7 @@ function _contract!(α, A::AbstractTensorMap, B::AbstractTensorMap,
     end
     A′ = permute(A, (oindA, cindA); copy=copyA)
     B′ = permute(B, (cindB, oindB))
-    if BraidingStyle(sectortype(S)) isa Fermionic
+    if BraidingStyle(sectortype(A)) isa Fermionic
         for i in domainind(A′)
             if !isdual(space(A′, i))
                 A′ = twist!(A′, i)

--- a/test/planar.jl
+++ b/test/planar.jl
@@ -12,13 +12,13 @@ function force_planar(V::GradedSpace)
     return GradedSpace((c ⊠ PlanarTrivial() => dim(V, c) for c in sectors(V))..., isdual(V))
 end
 force_planar(V::ProductSpace) = mapreduce(force_planar, ⊗, V)
-function force_planar(tsrc::TensorMap{ComplexSpace})
+function force_planar(tsrc::TensorMap{<:Any,ComplexSpace})
     tdst = TensorMap(undef, scalartype(tsrc),
                      force_planar(codomain(tsrc)) ← force_planar(domain(tsrc)))
     copyto!(blocks(tdst)[PlanarTrivial()], blocks(tsrc)[Trivial()])
     return tdst
 end
-function force_planar(tsrc::TensorMap{<:GradedSpace})
+function force_planar(tsrc::TensorMap{<:Any,<:GradedSpace})
     tdst = TensorMap(undef, scalartype(tsrc),
                      force_planar(codomain(tsrc)) ← force_planar(domain(tsrc)))
     for (c, b) in blocks(tsrc)


### PR DESCRIPTION
This adds the scalartype as part of the `AbstractTensorMap` interface.

Additionally, in order to facilitate further subtyping, I made some changes that try to make ambiguity errors less likely to show up. [doc page](https://docs.julialang.org/en/v1/manual/methods/#man-method-design-ambiguities) and [specific heading](https://docs.julialang.org/en/v1/manual/methods/#Abstract-containers-and-element-types).