### PR TITLE
Change `copy(BraidingTensor)` to return a `BraidingTensor`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -21,3 +21,11 @@ This adds the scalar type as a parameter to the `AbstractTensorMap` type. This i
 the contexts where different types of tensors are used (`AdjointTensor`, `BraidingTensor`,
 ...), which still have the same scalartype. Additionally, this removes many specializations
 for methods in order to reduce ambiguity errors.
+
+### `copy(BraidingTensor`
+
+This PR changes the behaviour of `copy` as an instantiator for creating a `TensorMap` from a
+`BraidingTensor`. The rationale is that while this does sometimes happen in Julia `Base`,
+this is always in the context of lazy wrapper types, for which it makes sense to not copy
+the parent and then create a new wrapper. `BraidingTensor` does not wrap anything, so this
+definition makes less sense.

--- a/src/tensors/braidingtensor.jl
+++ b/src/tensors/braidingtensor.jl
@@ -150,8 +150,8 @@ function Base.copy!(t::TensorMap, b::BraidingTensor)
     end
     return t
 end
-TensorMap(b::BraidingTensor) = copy(b)
-Base.convert(::Type{TensorMap}, b::BraidingTensor) = copy(b)
+TensorMap(b::BraidingTensor) = copy!(similar(b), b)
+Base.convert(::Type{TensorMap}, b::BraidingTensor) = TensorMap(b)
 
 function block(b::BraidingTensor, s::Sector)
     sectortype(b) == typeof(s) || throw(SectorMismatch())
@@ -201,7 +201,7 @@ function add_transform!(tdst::AbstractTensorMap,
                         α::Number,
                         β::Number,
                         backend::Backend...)
-    return add_transform!(tdst, copy(tsrc), (p₁, p₂), fusiontreetransform, α, β, backend...)
+    return add_transform!(tdst, TensorMap(tsrc), (p₁, p₂), fusiontreetransform, α, β, backend...)
 end
 
 # VectorInterface
@@ -215,7 +215,7 @@ end
 function TO.tensoradd!(C::AbstractTensorMap, pC::Index2Tuple,
                        A::BraidingTensor, conjA::Symbol, α::Number, β::Number,
                        backend::Backend...)
-    return TO.tensoradd!(C, pC, copy(A), conjA, α, β, backend...)
+    return TO.tensoradd!(C, pC, TensorMap(A), conjA, α, β, backend...)
 end
 
 # Planar operations
@@ -226,7 +226,7 @@ function planaradd!(C::AbstractTensorMap,
                     A::BraidingTensor, p::Index2Tuple,
                     α::Number, β::Number,
                     backend::Backend...)
-    return planaradd!(C, copy(A), p, α, β, backend...)
+    return planaradd!(C, TensorMap(A), p, α, β, backend...)
 end
 
 function planarcontract!(C::AbstractTensorMap,
@@ -239,7 +239,7 @@ function planarcontract!(C::AbstractTensorMap,
                          backend::Backend...)
     # special case only defined for contracting 2 indices
     length(oindA) == length(cindA) == 2 ||
-        return planarcontract!(C, copy(A), (oindA, cindA), B, (cindB, oindB), (p1, p2),
+        return planarcontract!(C, TensorMap(A), (oindA, cindA), B, (cindB, oindB), (p1, p2),
                                α, β, backend...)
 
     codA, domA = codomainind(A), domainind(A)
@@ -290,7 +290,7 @@ function planarcontract!(C::AbstractTensorMap,
                          backend::Backend...)
     # special case only defined for contracting 2 indices
     length(oindB) == length(cindB) == 2 ||
-        return planarcontract!(C, A, (oindA, cindA), copy(B), (cindB, oindB), (p1, p2),
+        return planarcontract!(C, A, (oindA, cindA), TensorMap(B), (cindB, oindB), (p1, p2),
                                α, β, backend...)
 
     codA, domA = codomainind(A), domainind(A)
@@ -336,7 +336,7 @@ end
 function planarcontract!(C::AbstractTensorMap, A::BraidingTensor, pA::Index2Tuple,
                          B::BraidingTensor, pB::Index2Tuple, pC::Index2Tuple,
                          α::Number, β::Number, backend::Backend...)
-    return planarcontract!(C, copy(A), pA, copy(B), pB, pC, α, β, backend...)
+    return planarcontract!(C, TensorMap(A), pA, TensorMap(B), pB, pC, α, β, backend...)
 end
 
 function planartrace!(C::AbstractTensorMap,
@@ -344,7 +344,7 @@ function planartrace!(C::AbstractTensorMap,
                       p::Index2Tuple, q::Index2Tuple,
                       α::Number, β::Number,
                       backend::Backend...)
-    return planartrace!(C, copy(A), p, q, α, β, backend...)
+    return planartrace!(C, TensorMap(A), p, q, α, β, backend...)
 end
 
 # function planarcontract!(C::AbstractTensorMap{S,N₁,N₂},

--- a/src/tensors/braidingtensor.jl
+++ b/src/tensors/braidingtensor.jl
@@ -201,7 +201,8 @@ function add_transform!(tdst::AbstractTensorMap,
                         α::Number,
                         β::Number,
                         backend::Backend...)
-    return add_transform!(tdst, TensorMap(tsrc), (p₁, p₂), fusiontreetransform, α, β, backend...)
+    return add_transform!(tdst, TensorMap(tsrc), (p₁, p₂), fusiontreetransform, α, β,
+                          backend...)
 end
 
 # VectorInterface

--- a/src/tensors/braidingtensor.jl
+++ b/src/tensors/braidingtensor.jl
@@ -127,7 +127,9 @@ end
 
 Base.similar(::BraidingTensor, T::Type, P::TensorMapSpace) = TensorMap(undef, T, P)
 
-Base.copy(b::BraidingTensor) = copy!(similar(b), b)
+# efficient copy constructor
+Base.copy(b::BraidingTensor) = BraidingTensor(copy(b.V1), copy(b.V2), b.adjoint)
+
 function Base.copy!(t::TensorMap, b::BraidingTensor)
     space(t) == space(b) || throw(SectorMismatch())
     fill!(t, zero(scalartype(t)))

--- a/src/tensors/tensor.jl
+++ b/src/tensors/tensor.jl
@@ -571,7 +571,8 @@ since it assumes a  uniquely defined coupled charge.
 """
 @inline function Base.getindex(t::TensorMap, sectors::Tuple{I,Vararg{I}}) where {I<:Sector}
     I === sectortype(t) || throw(SectorMismatch("Not a valid sectortype for this tensor."))
-    length(sectors) == numind(t) || throw(ArgumentError("Number of sectors does not match."))
+    length(sectors) == numind(t) ||
+        throw(ArgumentError("Number of sectors does not match."))
     FusionStyle(I) isa UniqueFusion ||
         throw(SectorMismatch("Indexing with sectors only possible if unique fusion"))
     s1 = TupleTools.getindices(sectors, codomainind(t))
@@ -757,7 +758,7 @@ function Base.convert(T::Type{<:TensorMap{E,S,N₁,N₂}},
         return t
     else
         data = Dict{sectortype(T),storagetype(T)}(c => convert(storagetype(T), b)
-                                      for (c, b) in blocks(t))
+                                                  for (c, b) in blocks(t))
         return TensorMap(data, codomain(t), domain(t))
     end
 end

--- a/test/braidingtensor.jl
+++ b/test/braidingtensor.jl
@@ -13,119 +13,119 @@ for V in (V1, V2, V3)
 
     t = TensorMap(randn, V * V' * V' * V, V * V')
 
-    ττ = copy(BraidingTensor(V, V'))
+    ττ = TensorMap(BraidingTensor(V, V'))
     @planar2 t1[-1 -2 -3 -4; -5 -6] := τ[-1 -2; 1 2] * t[1 2 -3 -4; -5 -6]
     @planar2 t2[-1 -2 -3 -4; -5 -6] := ττ[-1 -2; 1 2] * t[1 2 -3 -4; -5 -6]
     @planar2 t3[-1 -2 -3 -4; -5 -6] := τ[2 1; -2 -1] * t[1 2 -3 -4; -5 -6]
     @planar2 t4[-1 -2 -3 -4; -5 -6] := τ'[-2 2; -1 1] * t[1 2 -3 -4; -5 -6]
     @show norm(t1 - t2), norm(t1 - t3), norm(t1 - t4)
 
-    ττ = copy(BraidingTensor(V', V'))
+    ττ = TensorMap(BraidingTensor(V', V'))
     @planar2 t1[-1 -2 -3 -4; -5 -6] := τ[-2 -3; 1 2] * t[-1 1 2 -4; -5 -6]
     @planar2 t2[-1 -2 -3 -4; -5 -6] := ττ[-2 -3; 1 2] * t[-1 1 2 -4; -5 -6]
     @planar2 t3[-1 -2 -3 -4; -5 -6] := τ[2 1; -3 -2] * t[-1 1 2 -4; -5 -6]
     @planar2 t4[-1 -2 -3 -4; -5 -6] := τ'[-3 2; -2 1] * t[-1 1 2 -4; -5 -6]
     @show norm(t1 - t2), norm(t1 - t3), norm(t1 - t4)
 
-    ττ = copy(BraidingTensor(V', V))
+    ττ = TensorMap(BraidingTensor(V', V))
     @planar2 t1[-1 -2 -3 -4; -5 -6] := τ[1 -2; 2 -3] * t[-1 1 2 -4; -5 -6]
     @planar2 t2[-1 -2 -3 -4; -5 -6] := ττ[1 -2; 2 -3] * t[-1 1 2 -4; -5 -6]
     @planar2 t3[-1 -2 -3 -4; -5 -6] := τ[-3 2; -2 1] * t[-1 1 2 -4; -5 -6]
     @planar2 t4[-1 -2 -3 -4; -5 -6] := τ'[-2 -3; 1 2] * t[-1 1 2 -4; -5 -6]
     @show norm(t1 - t2), norm(t1 - t3), norm(t1 - t4)
 
-    ττ = copy(BraidingTensor(V, V'))
+    ττ = TensorMap(BraidingTensor(V, V'))
     @planar2 t1[-1 -2 -3 -4; -5 -6] := τ[-3 2; -2 1] * t[-1 1 2 -4; -5 -6]
     @planar2 t2[-1 -2 -3 -4; -5 -6] := ττ[-3 2; -2 1] * t[-1 1 2 -4; -5 -6]
     @planar2 t3[-1 -2 -3 -4; -5 -6] := τ[1 -2; 2 -3] * t[-1 1 2 -4; -5 -6]
     @planar2 t4[-1 -2 -3 -4; -5 -6] := τ'[2 1; -3 -2] * t[-1 1 2 -4; -5 -6]
     @show norm(t1 - t2), norm(t1 - t3), norm(t1 - t4)
 
-    ττ = copy(BraidingTensor(V, V))
+    ττ = TensorMap(BraidingTensor(V, V))
     @planar2 t1[-1 -2 -3 -4; -5 -6] := τ[2 1; -3 -2] * t[-1 1 2 -4; -5 -6]
     @planar2 t2[-1 -2 -3 -4; -5 -6] := ττ[2 1; -3 -2] * t[-1 1 2 -4; -5 -6]
     @planar2 t3[-1 -2 -3 -4; -5 -6] := τ[-2 -3; 1 2] * t[-1 1 2 -4; -5 -6]
     @planar2 t4[-1 -2 -3 -4; -5 -6] := τ'[1 -2; 2 -3] * t[-1 1 2 -4; -5 -6]
     @show norm(t1 - t2), norm(t1 - t3), norm(t1 - t4)
 
-    ττ = copy(BraidingTensor(V', V))
+    ττ = TensorMap(BraidingTensor(V', V))
     @planar2 t1[-1 -2 -3 -4; -5 -6] := τ[-3 -4; 1 2] * t[-1 -2 1 2; -5 -6]
     @planar2 t2[-1 -2 -3 -4; -5 -6] := ττ[-3 -4; 1 2] * t[-1 -2 1 2; -5 -6]
     @planar2 t3[-1 -2 -3 -4; -5 -6] := τ[2 1; -4 -3] * t[-1 -2 1 2; -5 -6]
     @planar2 t4[-1 -2 -3 -4; -5 -6] := τ'[-4 2; -3 1] * t[-1 -2 1 2; -5 -6]
     @show norm(t1 - t2), norm(t1 - t3), norm(t1 - t4)
 
-    ττ = copy(BraidingTensor(V', V))
+    ττ = TensorMap(BraidingTensor(V', V))
     @planar2 t1[-1 -2 -3 -4; -5 -6] := t[-1 -2 -3 -4; 1 2] * τ[1 2; -5 -6]
     @planar2 t2[-1 -2 -3 -4; -5 -6] := t[-1 -2 -3 -4; 1 2] * ττ[1 2; -5 -6]
     @planar2 t3[-1 -2 -3 -4; -5 -6] := t[-1 -2 -3 -4; 1 2] * τ[-6 -5; 2 1]
     @planar2 t4[-1 -2 -3 -4; -5 -6] := t[-1 -2 -3 -4; 1 2] * τ'[2 -6; 1 -5]
     @show norm(t1 - t2), norm(t1 - t3), norm(t1 - t4)
 
-    ττ = copy(BraidingTensor(V, V'))
+    ττ = TensorMap(BraidingTensor(V, V'))
     @planar2 t1[-1 -2 -3 -4; -5 -6] := t[-1 -2 -3 -4; 1 2] * τ'[1 2; -5 -6]
     @planar2 t2[-1 -2 -3 -4; -5 -6] := t[-1 -2 -3 -4; 1 2] * ττ'[1 2; -5 -6]
     @planar2 t3[-1 -2 -3 -4; -5 -6] := t[-1 -2 -3 -4; 1 2] * τ'[-6 -5; 2 1]
     @planar2 t4[-1 -2 -3 -4; -5 -6] := t[-1 -2 -3 -4; 1 2] * τ[2 -6; 1 -5]
     @show norm(t1 - t2), norm(t1 - t3), norm(t1 - t4)
 
-    ττ = copy(BraidingTensor(V, V))
+    ττ = TensorMap(BraidingTensor(V, V))
     @planar2 t1[-1 -2 -3 -4; -5 -6] := t[-1 -2 -3 1; -5 2] * τ[-4 -6; 1 2]
     @planar2 t2[-1 -2 -3 -4; -5 -6] := t[-1 -2 -3 1; -5 2] * ττ[-4 -6; 1 2]
     @planar2 t3[-1 -2 -3 -4; -5 -6] := t[-1 -2 -3 1; -5 2] * τ[2 1; -6 -4]
     @planar2 t4[-1 -2 -3 -4; -5 -6] := t[-1 -2 -3 1; -5 2] * τ'[-6 2; -4 1]
     @show norm(t1 - t2), norm(t1 - t3), norm(t1 - t4)
 
-    ττ = copy(BraidingTensor(V', V))
+    ττ = TensorMap(BraidingTensor(V', V))
     @planar2 t1[(); (-1, -2)] := τ[2 1; 3 4] * t[1 2 3 4; -1 -2]
     @planar2 t2[(); (-1, -2)] := ττ[2 1; 3 4] * t[1 2 3 4; -1 -2]
     @planar2 t3[(); (-1, -2)] := τ[4 3; 1 2] * t[1 2 3 4; -1 -2]
     @planar2 t4[(); (-1, -2)] := τ'[1 4; 2 3] * t[1 2 3 4; -1 -2]
     @show norm(t1 - t2), norm(t1 - t3), norm(t1 - t4)
 
-    ττ = copy(BraidingTensor(V, V))
+    ττ = TensorMap(BraidingTensor(V, V))
     @planar2 t1[-1; -2] := τ[2 1; 3 4] * t[-1 1 2 3; -2 4]
     @planar2 t2[-1; -2] := ττ[2 1; 3 4] * t[-1 1 2 3; -2 4]
     @planar2 t3[-1; -2] := τ[4 3; 1 2] * t[-1 1 2 3; -2 4]
     @planar2 t4[-1; -2] := τ'[1 4; 2 3] * t[-1 1 2 3; -2 4]
     @show norm(t1 - t2), norm(t1 - t3), norm(t1 - t4)
 
-    ττ = copy(BraidingTensor(V, V'))
+    ττ = TensorMap(BraidingTensor(V, V'))
     @planar2 t1[-1 -2] := τ[2 1; 3 4] * t[-1 -2 1 2; 4 3]
     @planar2 t2[-1 -2] := ττ[2 1; 3 4] * t[-1 -2 1 2; 4 3]
     @planar2 t3[-1 -2] := τ[4 3; 1 2] * t[-1 -2 1 2; 4 3]
     @planar2 t4[-1 -2] := τ'[1 4; 2 3] * t[-1 -2 1 2; 4 3]
     @show norm(t1 - t2), norm(t1 - t3), norm(t1 - t4)
 
-    ττ = copy(BraidingTensor(V, V'))
+    ττ = TensorMap(BraidingTensor(V, V'))
     @planar2 t1[-1 -2; -3 -4] := τ[-1 3; 1 2] * t[1 2 3 -2; -3 -4]
     @planar2 t2[-1 -2; -3 -4] := ττ[-1 3; 1 2] * t[1 2 3 -2; -3 -4]
     @planar2 t3[-1 -2; -3 -4] := τ[2 1; 3 -1] * t[1 2 3 -2; -3 -4]
     @planar2 t4[-1 -2; -3 -4] := τ'[3 2; -1 1] * t[1 2 3 -2; -3 -4]
     @show norm(t1 - t2), norm(t1 - t3), norm(t1 - t4)
 
-    ττ = copy(BraidingTensor(V', V'))
+    ττ = TensorMap(BraidingTensor(V', V'))
     @planar2 t1[-1 -2; -3 -4] := τ'[-2 3; 1 2] * t[-1 1 2 3; -3 -4]
     @planar2 t2[-1 -2; -3 -4] := ττ'[-2 3; 1 2] * t[-1 1 2 3; -3 -4]
     @planar2 t3[-1 -2; -3 -4] := τ'[2 1; 3 -2] * t[-1 1 2 3; -3 -4]
     @planar2 t4[-1 -2; -3 -4] := τ[3 2; -2 1] * t[-1 1 2 3; -3 -4]
     @show norm(t1 - t2), norm(t1 - t3), norm(t1 - t4)
 
-    ττ = copy(BraidingTensor(V', V))
+    ττ = TensorMap(BraidingTensor(V', V))
     @planar2 t1[-1 -2 -3; -4] := τ[-3 3; 1 2] * t[-1 -2 1 2; -4 3]
     @planar2 t2[-1 -2 -3; -4] := ττ[-3 3; 1 2] * t[-1 -2 1 2; -4 3]
     @planar2 t3[-1 -2 -3; -4] := τ[2 1; 3 -3] * t[-1 -2 1 2; -4 3]
     @planar2 t4[-1 -2 -3; -4] := τ'[3 2; -3 1] * t[-1 -2 1 2; -4 3]
     @show norm(t1 - t2), norm(t1 - t3), norm(t1 - t4)
 
-    ττ = copy(BraidingTensor(V', V))
+    ττ = TensorMap(BraidingTensor(V', V))
     @planar2 t1[-1 -2 -3; -4] := t[-1 -2 -3 3; 1 2] * τ[1 2; -4 3]
     @planar2 t2[-1 -2 -3; -4] := t[-1 -2 -3 3; 1 2] * ττ[1 2; -4 3]
     @planar2 t3[-1 -2 -3; -4] := t[-1 -2 -3 3; 1 2] * τ[3 -4; 2 1]
     @planar2 t4[-1 -2 -3; -4] := t[-1 -2 -3 3; 1 2] * τ'[2 3; 1 -4]
     @show norm(t1 - t2), norm(t1 - t3), norm(t1 - t4)
 
-    ττ = copy(BraidingTensor(V, V'))
+    ττ = TensorMap(BraidingTensor(V, V'))
     @planar2 t1[-1 -2 -3; -4] := t[-1 -2 -3 3; 1 2] * τ'[1 2; -4 3]
     @planar2 t2[-1 -2 -3; -4] := t[-1 -2 -3 3; 1 2] * ττ'[1 2; -4 3]
     @planar2 t3[-1 -2 -3; -4] := t[-1 -2 -3 3; 1 2] * τ'[3 -4; 2 1]


### PR DESCRIPTION
This PR changes the behaviour of `copy` as an instantiator for creating a `TensorMap` from a `BraidingTensor`.
The rationale is that while this does sometimes happen in Julia `Base`, this is always in the context of lazy wrapper types, for which it makes sense to not copy the parent and then create a new wrapper. `BraidingTensor` does not wrap anything, so this definition makes less sense.