### PR TITLE
improve and fix copy(::BraidingTensor)

### DIFF
--- a/src/tensors/braidingtensor.jl
+++ b/src/tensors/braidingtensor.jl
@@ -128,7 +128,7 @@ end
 Base.similar(::BraidingTensor, T::Type, P::TensorMapSpace) = TensorMap(undef, T, P)
 
 # efficient copy constructor
-Base.copy(b::BraidingTensor) = BraidingTensor(copy(b.V1), copy(b.V2), b.adjoint)
+Base.copy(b::BraidingTensor{E, S}) where {E, S} = BraidingTensor{E, S}(b.V1, b.V2, b.adjoint)
 
 function Base.copy!(t::TensorMap, b::BraidingTensor)
     space(t) == space(b) || throw(SectorMismatch())


### PR DESCRIPTION
Copy type params and stop using `copy(b.V1)` and `copy(b.V2)` as `copy(::ComplexSpace)` doesn't exist.