### PR TITLE
fix and improve copy(::BraidingTensor)

### DIFF
--- a/src/tensors/braidingtensor.jl
+++ b/src/tensors/braidingtensor.jl
@@ -128,7 +128,7 @@ end
 Base.similar(::BraidingTensor, T::Type, P::TensorMapSpace) = TensorMap(undef, T, P)
 
 # efficient copy constructor
-Base.copy(b::BraidingTensor) = BraidingTensor(copy(b.V1), copy(b.V2), b.adjoint)
+Base.copy(b::BraidingTensor{E, S}) where {E, S} = BraidingTensor{E, S}(b.V1, b.V2, b.adjoint)
 
 function Base.copy!(t::TensorMap, b::BraidingTensor)
     space(t) == space(b) || throw(SectorMismatch())

--- a/src/tensors/braidingtensor.jl
+++ b/src/tensors/braidingtensor.jl
@@ -128,7 +128,7 @@ end
 Base.similar(::BraidingTensor, T::Type, P::TensorMapSpace) = TensorMap(undef, T, P)
 
 # efficient copy constructor
-Base.copy(b::BraidingTensor{E, S}) where {E, S} = BraidingTensor{E, S}(b.V1, b.V2, b.adjoint)
+Base.copy(b::BraidingTensor{E,S}) where {E,S} = BraidingTensor{E,S}(b.V1, b.V2, b.adjoint)
 
 function Base.copy!(t::TensorMap, b::BraidingTensor)
     space(t) == space(b) || throw(SectorMismatch())


### PR DESCRIPTION
copy type parameters and stop using `copy(b.V1)` & `copy(b.V2)` as `copy(::ComplexSpace)` does not exist